### PR TITLE
no round for avg

### DIFF
--- a/lib/fluent/plugin/out_numeric_monitor.rb
+++ b/lib/fluent/plugin/out_numeric_monitor.rb
@@ -113,7 +113,7 @@ class Fluent::NumericMonitorOutput < Fluent::Output
       if c[:num] then output['num'] = c[:num] end
       if c[:min] then output['min'] = c[:min] end
       if c[:max] then output['max'] = c[:max] end
-      if c[:num] > 0 then output['avg'] = (c[:sum] * 100.0 / (c[:num] * 1.0)).round / 100.0 end
+      if c[:num] > 0 then output['avg'] = (c[:sum] / (c[:num] * 1.0)) end
       if @percentiles
         sorted = c[:sample].sort
         @percentiles.each do |p|
@@ -133,7 +133,7 @@ class Fluent::NumericMonitorOutput < Fluent::Output
       if c[:num] then output[t + '_num'] = c[:num] end
       if c[:min] then output[t + '_min'] = c[:min] end
       if c[:max] then output[t + '_max'] = c[:max] end
-      if c[:num] > 0 then output[t + '_avg'] = (c[:sum] * 100.0 / (c[:num] * 1.0)).round / 100.0 end
+      if c[:num] > 0 then output[t + '_avg'] = (c[:sum] / (c[:num] * 1.0)) end
       if @percentiles
         sorted = c[:sample].sort
         @percentiles.each do |p|


### PR DESCRIPTION
The formula to calculate avg makes us lose precision. Are there any reason to round at the second decimal place?
