### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# fluent-plugin-numeric-monitor, a plugin for [Fluentd](http://fluentd.org)
+# fluent-plugin-numeric-monitor
 
 ## Component
 
 ### NumericMonitorOutput
 
-Plugin to calculate min/max/avg/sum and specified percentile values (and 'num' of matched messages), which used in notifications (such as fluent-plugin-notifier)
+[Fluentd](http://fluentd.org) plugin to calculate min/max/avg/sum and specified percentile values (and 'num' of matched messages), which used in notifications (such as fluent-plugin-notifier)
 
 ## Configuration
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
