### PR TITLE
Fix "comparison of Float with nil failed"

### DIFF
--- a/lib/fluent/plugin/out_numeric_monitor.rb
+++ b/lib/fluent/plugin/out_numeric_monitor.rb
@@ -192,10 +192,10 @@ class Fluent::Plugin::NumericMonitorOutput < Fluent::Plugin::Output
     @mutex.synchronize do
       c = (@count[tag] ||= {min: nil, max: nil, sum: nil, num: 0})
 
-      if c[:min].nil? or c[:min] > min
+      if c[:min].nil? or (min and c[:min] > min)
         c[:min] = min
       end
-      if c[:max].nil? or c[:max] < max
+      if c[:max].nil? or (max and c[:max] < max)
         c[:max] = max
       end
       c[:sum] = (c[:sum] || 0) + sum

--- a/test/plugin/test_out_numeric_monitor.rb
+++ b/test/plugin/test_out_numeric_monitor.rb
@@ -407,31 +407,26 @@ class NumericMonitorOutputTest < Test::Unit::TestCase
 
   def test_emit_with_nil_values
     d = create_driver(CONFIG)
-    begin
-      d.run(default_tag: 'test.tag1') do
-        10.times do
-          d.feed({'field1' => nil})
-          d.feed({'field1' => 1})
-          d.feed({'field1' => 2})
-          d.feed({'field1' => 3})
-          d.feed({'field1' => 4})
-          d.feed({'field1' => 5})
-          d.feed({'field1' => 6})
-          d.feed({'field1' => 7})
-          d.feed({'field1' => 8})
-          d.feed({'field1' => 9})
-        end
+    d.run(default_tag: 'test.tag1') do
+      10.times do
+        d.feed({'field1' => nil})
+        d.feed({'field1' => 1})
+        d.feed({'field1' => 2})
+        d.feed({'field1' => 3})
+        d.feed({'field1' => 4})
+        d.feed({'field1' => 5})
+        d.feed({'field1' => 6})
+        d.feed({'field1' => 7})
+        d.feed({'field1' => 8})
+        d.feed({'field1' => 9})
       end
-      r1 = d.instance.flush
-      assert_equal 1, r1['tag1_min']
-      assert_equal 9, r1['tag1_max']
-      assert_equal 5, r1['tag1_avg']
-      assert_equal 450, r1['tag1_sum']
-      assert_equal 8, r1['tag1_percentile_80']
-      assert_equal 9, r1['tag1_percentile_90']
-      assert_equal 90, r1['tag1_num']
-    end
-  rescue => e
-    flunk(e)
+    r1 = d.instance.flush
+    assert_equal 1, r1['tag1_min']
+    assert_equal 9, r1['tag1_max']
+    assert_equal 5, r1['tag1_avg']
+    assert_equal 450, r1['tag1_sum']
+    assert_equal 8, r1['tag1_percentile_80']
+    assert_equal 9, r1['tag1_percentile_90']
+    assert_equal 90, r1['tag1_num']
   end
 end

--- a/test/plugin/test_out_numeric_monitor.rb
+++ b/test/plugin/test_out_numeric_monitor.rb
@@ -408,25 +408,24 @@ class NumericMonitorOutputTest < Test::Unit::TestCase
   def test_emit_with_nil_values
     d = create_driver(CONFIG)
     d.run(default_tag: 'test.tag1') do
-      10.times do
-        d.feed({'field1' => nil})
-        d.feed({'field1' => 1})
-        d.feed({'field1' => 2})
-        d.feed({'field1' => 3})
-        d.feed({'field1' => 4})
-        d.feed({'field1' => 5})
-        d.feed({'field1' => 6})
-        d.feed({'field1' => 7})
-        d.feed({'field1' => 8})
-        d.feed({'field1' => 9})
-      end
+      d.feed({'field1' => nil})
+      d.feed({'field1' => 1})
+      d.feed({'field1' => 2})
+      d.feed({'field1' => 3})
+      d.feed({'field1' => 4})
+      d.feed({'field1' => 5})
+      d.feed({'field1' => 6})
+      d.feed({'field1' => 7})
+      d.feed({'field1' => 8})
+      d.feed({'field1' => 9})
+    end
     r1 = d.instance.flush
     assert_equal 1, r1['tag1_min']
     assert_equal 9, r1['tag1_max']
     assert_equal 5, r1['tag1_avg']
-    assert_equal 450, r1['tag1_sum']
-    assert_equal 8, r1['tag1_percentile_80']
-    assert_equal 9, r1['tag1_percentile_90']
-    assert_equal 90, r1['tag1_num']
+    assert_equal 45, r1['tag1_sum']
+    assert_equal 7, r1['tag1_percentile_80']
+    assert_equal 8, r1['tag1_percentile_90']
+    assert_equal 9, r1['tag1_num']
   end
 end

--- a/test/plugin/test_out_numeric_monitor.rb
+++ b/test/plugin/test_out_numeric_monitor.rb
@@ -404,4 +404,34 @@ class NumericMonitorOutputTest < Test::Unit::TestCase
     assert_equal 12, r['key_prefix_sum']
     assert_equal 6, r['key_prefix_num']
   end
+
+  def test_emit_with_nil_values
+    d = create_driver(CONFIG)
+    begin
+      d.run(default_tag: 'test.tag1') do
+        10.times do
+          d.feed({'field1' => nil})
+          d.feed({'field1' => 1})
+          d.feed({'field1' => 2})
+          d.feed({'field1' => 3})
+          d.feed({'field1' => 4})
+          d.feed({'field1' => 5})
+          d.feed({'field1' => 6})
+          d.feed({'field1' => 7})
+          d.feed({'field1' => 8})
+          d.feed({'field1' => 9})
+        end
+      end
+      r1 = d.instance.flush
+      assert_equal 1, r1['tag1_min']
+      assert_equal 9, r1['tag1_max']
+      assert_equal 5, r1['tag1_avg']
+      assert_equal 450, r1['tag1_sum']
+      assert_equal 8, r1['tag1_percentile_80']
+      assert_equal 9, r1['tag1_percentile_90']
+      assert_equal 90, r1['tag1_num']
+    end
+  rescue => e
+    flunk(e)
+  end
 end

--- a/test/plugin/test_out_numeric_monitor.rb
+++ b/test/plugin/test_out_numeric_monitor.rb
@@ -408,8 +408,8 @@ class NumericMonitorOutputTest < Test::Unit::TestCase
   def test_emit_with_nil_values
     d = create_driver(CONFIG)
     d.run(default_tag: 'test.tag1') do
-      d.feed({'field1' => nil})
       d.feed({'field1' => 1})
+      d.feed({'field1' => nil})
       d.feed({'field1' => 2})
       d.feed({'field1' => 3})
       d.feed({'field1' => 4})


### PR DESCRIPTION
to fix this ArgumentError

```
2024-07-01 18:29:11 +0900 [warn]: #0 emit transaction failed: error_class=ArgumentError error="comparison of Float with nil failed" location="/var/lib/td-agent/vendor/bundle/ruby/3.1.0/gems/fluent-plugin-numeric-monitor-1.0.3/lib/fluent/plugin/out_numeric_monitor.rb:195:in `>'" tag="*******************"
```